### PR TITLE
changed Stock ID to change Tag of IR rolling stock

### DIFF
--- a/src/main/java/com/clussmanproductions/railstuff/event/EntityIdentifierRenderer.java
+++ b/src/main/java/com/clussmanproductions/railstuff/event/EntityIdentifierRenderer.java
@@ -3,9 +3,9 @@ package com.clussmanproductions.railstuff.event;
 
 import java.util.List;
 
+import cam72cam.immersiverailroading.entity.EntityRollingStock;
 import org.lwjgl.opengl.GL11;
 
-import com.clussmanproductions.railstuff.data.RollingStockIdentificationData;
 import com.clussmanproductions.railstuff.item.ItemPaperwork;
 import com.clussmanproductions.railstuff.item.ItemRollingStockAssigner;
 import com.clussmanproductions.railstuff.network.PacketGetIdentifierForAssignGUI;
@@ -27,7 +27,8 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 
 @EventBusSubscriber(Side.CLIENT)
-public class EntityIdentifierRenderer {	
+public class EntityIdentifierRenderer {
+
 	public static void renderNameTag(Entity entity, float posX, float posY,
 			float posX2, RenderManager renderManager, FontRenderer fontRenderer, String name) {
 
@@ -92,7 +93,6 @@ public class EntityIdentifierRenderer {
 			return;
 		}
 		List<Entity> entities = Minecraft.getMinecraft().world.getLoadedEntityList();
-		RollingStockIdentificationData data = RollingStockIdentificationData.get(Minecraft.getMinecraft().world);
 		
 		for(Entity entity : entities)
 		{
@@ -100,17 +100,20 @@ public class EntityIdentifierRenderer {
 			{
 				continue;
 			}
-			String name = data.getIdentifierByUUID(entity.getPersistentID());
-			if (name.equals(""))
+
+			String apiTag = ((EntityRollingStock)entity).tag;
+
+			if (apiTag.equals(""))
 			{
 				continue;
 			}
-			
-			double x = interpolateValue(entity.prevPosX, entity.posX, e.getPartialTicks()) - Minecraft.getMinecraft().getRenderManager().renderViewEntity.posX;
+
+			double x = interpolateValue(entity.prevPosX, entity.posX, e.getPartialTicks())  - Minecraft.getMinecraft().getRenderManager().renderViewEntity.posX;
 			double y = interpolateValue(entity.prevPosY, entity.posY, e.getPartialTicks()) - Minecraft.getMinecraft().getRenderManager().renderViewEntity.posY;
 			double z = interpolateValue(entity.prevPosZ, entity.posZ, e.getPartialTicks()) - Minecraft.getMinecraft().getRenderManager().renderViewEntity.posZ;
-						
-			renderNameTag(entity, (float)x, (float)y, (float)z, Minecraft.getMinecraft().getRenderManager(), Minecraft.getMinecraft().getRenderManager().getFontRenderer(), name);
+
+			renderNameTag(entity, (float)x, (float)y, (float)z, Minecraft.getMinecraft().getRenderManager(), Minecraft.getMinecraft().getRenderManager().getFontRenderer(), apiTag);
+
 		}
 	}
 	

--- a/src/main/java/com/clussmanproductions/railstuff/event/PlayerInteractServerEventHandler.java
+++ b/src/main/java/com/clussmanproductions/railstuff/event/PlayerInteractServerEventHandler.java
@@ -1,5 +1,8 @@
 package com.clussmanproductions.railstuff.event;
 
+import cam72cam.immersiverailroading.entity.EntityRollingStock;
+import cam72cam.immersiverailroading.thirdparty.CommonAPI;
+import com.clussmanproductions.railstuff.ModRailStuff;
 import com.clussmanproductions.railstuff.data.RollingStockIdentificationData;
 import com.clussmanproductions.railstuff.item.ItemRollingStockAssigner;
 import com.clussmanproductions.railstuff.network.PacketHandler;
@@ -11,6 +14,7 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
+import org.apache.logging.log4j.Level;
 
 @EventBusSubscriber(Side.SERVER)
 public class PlayerInteractServerEventHandler {
@@ -40,13 +44,13 @@ public class PlayerInteractServerEventHandler {
 		int x = (int)Math.floor(entity.posX);
 		int y = (int)Math.floor(entity.posY);
 		int z = (int)Math.floor(entity.posZ);
-		
-		RollingStockIdentificationData data = RollingStockIdentificationData.get(e.getWorld());
-		String name = data.getIdentifierByUUID(e.getTarget().getPersistentID());
-		
+
+		EntityRollingStock stock = (EntityRollingStock) e.getTarget();
+		String apiTag = stock.tag;
+
 		PacketSetIdentifierForAssignGUI packet = new PacketSetIdentifierForAssignGUI();
 		packet.id = e.getTarget().getPersistentID();
-		packet.name = name;
+		packet.name = apiTag;
 		packet.x = x;
 		packet.y = y;
 		packet.z = z;

--- a/src/main/java/com/clussmanproductions/railstuff/event/PlayerJoinEventHandler.java
+++ b/src/main/java/com/clussmanproductions/railstuff/event/PlayerJoinEventHandler.java
@@ -29,11 +29,5 @@ public class PlayerJoinEventHandler {
 		
 		EntityPlayerMP player = (EntityPlayerMP)entity;
 		World world = e.getWorld();
-		RollingStockIdentificationData data = RollingStockIdentificationData.get(world);
-		
-		PacketSetAllIdentifiersForClient packet = new PacketSetAllIdentifiersForClient();
-		packet.values = data.getData();
-		
-		PacketHandler.INSTANCE.sendTo(packet, player);
 	}
 }

--- a/src/main/java/com/clussmanproductions/railstuff/gui/GuiAssignRollingStock.java
+++ b/src/main/java/com/clussmanproductions/railstuff/gui/GuiAssignRollingStock.java
@@ -27,7 +27,7 @@ public class GuiAssignRollingStock extends GuiScreen {
 		int horizontalCenter = width / 2;
 		int verticalCenter = height / 2;
 		text = new GuiTextField(0, fontRenderer, horizontalCenter - 150, verticalCenter, 300, 20);
-		text.setMaxStringLength(11);
+		//text.setMaxStringLength(11);
 		text.setVisible(true);
 		text.setFocused(true);
 		save = new GuiButton(1, horizontalCenter - 150, verticalCenter + 30, 300, 20, "Save");

--- a/src/main/java/com/clussmanproductions/railstuff/network/PacketGetIdentifierForAssignGUI.java
+++ b/src/main/java/com/clussmanproductions/railstuff/network/PacketGetIdentifierForAssignGUI.java
@@ -2,6 +2,8 @@ package com.clussmanproductions.railstuff.network;
 
 import java.util.UUID;
 
+import cam72cam.immersiverailroading.entity.EntityRollingStock;
+import cam72cam.immersiverailroading.thirdparty.CommonAPI;
 import com.clussmanproductions.railstuff.data.RollingStockIdentificationData;
 
 import io.netty.buffer.ByteBuf;
@@ -50,13 +52,12 @@ public class PacketGetIdentifierForAssignGUI implements IMessage {
 		private void handle(PacketGetIdentifierForAssignGUI message, MessageContext ctx)
 		{
 			World world = ctx.getServerHandler().player.world;
-			RollingStockIdentificationData data = RollingStockIdentificationData.get(world);
-			
-			String name = data.getIdentifierByUUID(message.id);
+			EntityRollingStock stock = world.getEntities(EntityRollingStock.class, p -> {return p.getPersistentID().equals(message.id);}).get(0);
+			String apiTag = stock.tag;
 			
 			PacketSetIdentifierForAssignGUI packet = new PacketSetIdentifierForAssignGUI();
 			packet.id = message.id;
-			packet.name = name;
+			packet.name = apiTag;
 			packet.x = message.x;
 			packet.y = message.y;
 			packet.z = message.z;

--- a/src/main/java/com/clussmanproductions/railstuff/network/PacketSetIdentifierOnServer.java
+++ b/src/main/java/com/clussmanproductions/railstuff/network/PacketSetIdentifierOnServer.java
@@ -1,8 +1,13 @@
 package com.clussmanproductions.railstuff.network;
 
 import java.util.UUID;
+import org.apache.logging.log4j.Level;
 
+import cam72cam.immersiverailroading.entity.EntityRollingStock;
+import cam72cam.immersiverailroading.thirdparty.CommonAPI;
+import com.clussmanproductions.railstuff.ModRailStuff;
 import com.clussmanproductions.railstuff.data.RollingStockIdentificationData;
+import com.google.common.base.Predicate;
 import com.jcraft.jogg.Packet;
 
 import io.netty.buffer.ByteBuf;
@@ -13,6 +18,8 @@ import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+
+import javax.annotation.Nullable;
 
 public class PacketSetIdentifierOnServer implements IMessage {
 
@@ -45,9 +52,10 @@ public class PacketSetIdentifierOnServer implements IMessage {
 		private void handle(PacketSetIdentifierOnServer message, MessageContext ctx)
 		{
 			World world = ctx.getServerHandler().player.world;
-			RollingStockIdentificationData data = RollingStockIdentificationData.get(world);
-			data.setIdentifierGivenUUID(message.id, message.newName);
-			
+
+			EntityRollingStock stock = (EntityRollingStock) world.getEntities(EntityRollingStock.class, p -> {return p.getPersistentID().equals(message.id);}).get(0);
+			stock.tag = message.newName;
+
 			PacketSetIdentifierForClient packet = new PacketSetIdentifierForClient();
 			packet.id = message.id;
 			packet.name = message.newName;

--- a/src/main/java/com/clussmanproductions/railstuff/proxy/ClientProxy.java
+++ b/src/main/java/com/clussmanproductions/railstuff/proxy/ClientProxy.java
@@ -1,9 +1,14 @@
 package com.clussmanproductions.railstuff.proxy;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 
+import cam72cam.immersiverailroading.entity.EntityRollingStock;
+import cam72cam.immersiverailroading.thirdparty.CommonAPI;
 import com.clussmanproductions.railstuff.ModBlocks;
 import com.clussmanproductions.railstuff.ModItems;
+import com.clussmanproductions.railstuff.ModRailStuff;
 import com.clussmanproductions.railstuff.blocks.model.ModelLoader;
 import com.clussmanproductions.railstuff.data.RollingStockIdentificationData;
 import com.clussmanproductions.railstuff.gui.GuiAssignRollingStock;
@@ -24,7 +29,9 @@ import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.relauncher.Side;
+import org.apache.logging.log4j.Level;
 
 @EventBusSubscriber(Side.CLIENT)
 public class ClientProxy extends CommonProxy {
@@ -45,31 +52,33 @@ public class ClientProxy extends CommonProxy {
 	public static void handleSetIdentifierForAssignGUI(PacketSetIdentifierForAssignGUI message)
 	{
 		World world = Minecraft.getMinecraft().world;
-		RollingStockIdentificationData data = RollingStockIdentificationData.get(world);
-		data.setIdentifierGivenUUID(message.id, message.name);
+		EntityRollingStock stock = world.getEntities(EntityRollingStock.class, p -> {return p.getPersistentID().equals(message.id);}).get(0);
 		EntityPlayerSP player = Minecraft.getMinecraft().player;
 		List<Entity> entities = world.getEntitiesWithinAABBExcludingEntity(player, new AxisAlignedBB(message.x-1, message.y-1, message.z-1, message.x+1, message.y+1, message.z+1));
 		if (entities.size() > 0)
 		{
 			GuiAssignRollingStock gui = new GuiAssignRollingStock(message.id);
 			Minecraft.getMinecraft().displayGuiScreen(gui);
-			gui.setText(message.name);
+			gui.setText(stock.tag);
 		}
 	}
 	
 	public static void handleSetAllIdentifiersForClient(PacketSetAllIdentifiersForClient message)
 	{
 		World world = Minecraft.getMinecraft().world;
-		RollingStockIdentificationData data = RollingStockIdentificationData.get(world);
-		data.setData(message.values);
+		for(UUID id : message.values.keySet()) {
+			String name = message.values.get(id);
+
+			EntityRollingStock stock = world.getEntities(EntityRollingStock.class, p -> {return p.getPersistentID().equals(id);}).get(0);
+			stock.tag = name;
+		}
 	}
 	
 	public static void handleSetIdentifierForClient(PacketSetIdentifierForClient message)
 	{
 		World world = Minecraft.getMinecraft().world;
-		RollingStockIdentificationData data = RollingStockIdentificationData.get(world);
-		
-		data.setIdentifierGivenUUID(message.id, message.name);
+		EntityRollingStock stock = world.getEntities(EntityRollingStock.class, p -> {return p.getPersistentID().equals(message.id);}).get(0);
+		stock.tag = message.name;
 	}
 
 }

--- a/src/main/java/com/clussmanproductions/railstuff/proxy/ServerProxy.java
+++ b/src/main/java/com/clussmanproductions/railstuff/proxy/ServerProxy.java
@@ -1,5 +1,53 @@
 package com.clussmanproductions.railstuff.proxy;
 
+import cam72cam.immersiverailroading.entity.EntityRollingStock;
+import com.clussmanproductions.railstuff.ModRailStuff;
+import com.clussmanproductions.railstuff.network.PacketHandler;
+import com.clussmanproductions.railstuff.network.PacketSetIdentifierForClient;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import org.apache.logging.log4j.Level;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+@EventBusSubscriber//(Side.SERVER)
 public class ServerProxy extends CommonProxy {
-	
+
+    @Override
+    public void init(FMLInitializationEvent event) {
+        super.init(event);
+        MinecraftForge.EVENT_BUS.register(this.getClass());
+    }
+
+    static HashMap<UUID, String> tags = new HashMap<>();
+
+    @SubscribeEvent
+    public static void onTick(TickEvent.WorldTickEvent e) {
+
+        World world = e.world;
+
+        for (EntityRollingStock stock : world.getEntities(EntityRollingStock.class, p -> {return true;})) {
+
+            UUID uuid = stock.getPersistentID();
+            String tag = stock.tag;
+
+            if (tags.containsKey(uuid) && tags.get(uuid).equals(tag))
+            {
+                continue;
+            }
+
+            tags.put(uuid, tag);
+
+            PacketSetIdentifierForClient packet = new PacketSetIdentifierForClient();
+            packet.name = tag;
+            packet.id = uuid;
+            PacketHandler.INSTANCE.sendToAll(packet);
+        }
+    }
 }


### PR DESCRIPTION
After I suggested to make your Stock ID work with the Tags from Immersive Railroading on Discord, I decided to try and do it myself. I basically changed it, so that instead of saving data in RollingStockIdentificationData (based on UUID), it accesses the rolling stock from immersive railroading and sets/gets its tag. I tested it, it also works when the tag is changed using OpenComputers, but that's why i have to constantly send SetIdentifierForClient-packets in the ServerProxy, maybe you can find a better solution to this.